### PR TITLE
Update gix monorepo

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Method to `PackageHandle` to get local version
 
+### Breaking Changes
+
+- Updated gix to 0.68.x and gix-object to 0.46.x
+
 ## [0.18.0]
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,12 +82,12 @@ directories = "5.0"
 dunce = "1.0"
 futures = "0.3"
 getset = { version = "0.1", optional = true }
-gix = { version = "0.67", features = [
+gix = { version = "0.68", features = [
     "blocking-http-transport-reqwest",
     "blocking-network-client",
     "worktree-mutation",
 ] }
-gix-object = "0.45"
+gix-object = "0.46"
 indicatif = { version = "0.17", features = ["improved_unicode", "tokio"] }
 itertools = "0.13"
 log = "0.4"


### PR DESCRIPTION
gix updated to `0.68`
gix-object updated to `0.46`

Supersedes #119 and #118.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a section for breaking changes in the changelog.
	- Introduced new structs and methods, including `EmptyConfig` and `InstallerHost`.

- **Breaking Changes**
	- Renamed several structs: `Downloader` to `DownloadHandle`, `AliasArray` to `NestedArray`, and removed `Uninstaller`.
	- Updated method signatures for `leaf()` and `CreateManifest`.

- **Bug Fixes**
	- Improved handling of empty hash strings to deserialize as `None`.

- **Chores**
	- Updated dependency versions and features in the `Cargo.toml` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->