### PR TITLE
Added constant to decide whether context needs elevation

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Method to `PackageHandle` to get local version
+- Constant to `ScoopContext` to check if the context requires elevation
 
 ### Breaking Changes
 

--- a/src/contexts.rs
+++ b/src/contexts.rs
@@ -86,6 +86,12 @@ pub trait ScoopContext: Clone + Send + Sync + 'static {
     /// This will default to the value of [`ScoopContext::APP_NAME`], but can be overridden.
     const CONTEXT_NAME: &'static str = Self::APP_NAME;
 
+    /// Whether the context requires elevation
+    ///
+    /// This should be `true` if the context requires elevation to run (i.e a global context)
+    /// and `false` if it does not (i.e a user context).
+    const ELEVATED: bool;
+
     /// Get a reference to the context's configuration
     fn config(&self) -> &Self::Config;
 
@@ -261,6 +267,8 @@ impl ScoopContext for AnyContext {
 
     const APP_NAME: &'static str = User::APP_NAME;
     const CONTEXT_NAME: &'static str = "Unknown context";
+    // TODO: Work out if there is a way to get this from the context
+    const ELEVATED: bool = false;
 
     fn config(&self) -> &config::Scoop {
         match self {

--- a/src/contexts/global.rs
+++ b/src/contexts/global.rs
@@ -58,6 +58,7 @@ impl ScoopContext for Global {
 
     const APP_NAME: &'static str = User::APP_NAME;
     const CONTEXT_NAME: &'static str = "global";
+    const ELEVATED: bool = true;
 
     fn config(&self) -> &config::Scoop {
         self.user_context.config()

--- a/src/contexts/user.rs
+++ b/src/contexts/user.rs
@@ -54,6 +54,7 @@ impl super::ScoopContext for User {
 
     const APP_NAME: &'static str = "scoop";
     const CONTEXT_NAME: &'static str = "user";
+    const ELEVATED: bool = false;
 
     /// Load the Scoop configuration
     ///


### PR DESCRIPTION
Closes #120 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added constants to indicate elevation requirements in the `ScoopContext`, `Global`, and `User` contexts.
	- Introduced a method for retrieving the local version in `PackageHandle`.
	- Enhanced support for compiling on non-Windows platforms.

- **Bug Fixes**
	- Fixed issues related to the `XDG_CONFIG_HOME` type.

- **Breaking Changes**
	- Updated dependencies and minimum supported Rust version.
	- Modified method signatures and removed obsolete features.

- **Documentation**
	- Improved clarity and detail in documentation for constants and methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->