### PR TITLE
Fix infinite recursion in TryFrom

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Infinite recursion in `TryFrom` trait for `VersionHandle`
+
 ## [0.19.0]
 
 ### Added

--- a/src/handles/version.rs
+++ b/src/handles/version.rs
@@ -78,6 +78,6 @@ impl TryFrom<PathBuf> for VersionHandle {
     type Error = Error;
 
     fn try_from(value: PathBuf) -> Result<Self, Self::Error> {
-        value.try_into()
+        TryFrom::<&Path>::try_from(&value)
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a method to retrieve the local version in `PackageHandle`.
	- Introduced a constant for elevation checks in `ScoopContext`.

- **Bug Fixes**
	- Resolved an infinite recursion issue in the `TryFrom` trait for `VersionHandle`.

- **Documentation**
	- Updated changelog to reflect new features, breaking changes, and fixes across multiple versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->