### PR TITLE
Use windows-latest for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       matrix:
         architecture: [i686, x86_64, aarch64]
     name: Build
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: windows-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure configuration to use GitHub-hosted runners for the Windows build job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->